### PR TITLE
rewrote HTML to make honeypot field less obvious to DOM readers

### DIFF
--- a/rcp-honeypot.php
+++ b/rcp-honeypot.php
@@ -16,18 +16,18 @@ class RCP_Honeypot {
 	}
 
 	public function error_checks() {
-		if( ! empty( $_POST['rcp_phone_field_002'] ) ) {
+		if( ! empty( $_POST['rcp_hp_phone_field_002'] ) ) {
 			rcp_errors()->add( 'spammer', __( 'Nice try spammer, feel free to try again', 'rcp' ), 'register' );
 		}
 	}
 
 	public function honeypot_field() {
 		?>
-		<p id="rcp_validation_wrap" style='display:none; position: absolute!important; left: -9000px;'>
-			<label for="rcp_phone_field_002">Phone</label>
-			<input name="rcp_phone_field_002" id="rcp_phone_field_002" type="text" placeholder="Phone">
+		<p id="rcp_hp_phone_field_002_wrap" style='display:none; position: absolute!important; left: -9000px;'>
+			<label for="rcp_hp_phone_field_002">Phone</label>
+			<input name="rcp_hp_phone_field_002" id="rcp_hp_phone_field_002" type="text" placeholder="Phone">
 		</p>
-		<?
+		<?php
 	}
 
 }

--- a/rcp-honeypot.php
+++ b/rcp-honeypot.php
@@ -11,18 +11,23 @@ class RCP_Honeypot {
 	public function __construct() {
 
 		add_action( 'rcp_form_errors',                 array( $this, 'error_checks'   ) );
-		add_action( 'rcp_before_register_form_fields', array( $this, 'honeypot_field' ) );
+		add_action( 'rcp_after_register_form_fields', array( $this, 'honeypot_field' ) );
 
 	}
 
 	public function error_checks() {
-		if( ! empty( $_POST['rcp_sugar_pot'] ) ) {
+		if( ! empty( $_POST['rcp_phone_field_002'] ) ) {
 			rcp_errors()->add( 'spammer', __( 'Nice try spammer, feel free to try again', 'rcp' ), 'register' );
 		}
 	}
 
 	public function honeypot_field() {
-		echo '<input type="hidden" name="rcp_sugar_pot" value=""/>';
+		?>
+		<p id="rcp_validation_wrap" style='display:none; position: absolute!important; left: -9000px;'>
+			<label for="rcp_phone_field_002">Phone</label>
+			<input name="rcp_phone_field_002" id="rcp_phone_field_002" type="text" placeholder="Phone">
+		</p>
+		<?
 	}
 
 }


### PR DESCRIPTION
I've modified the HTML and CSS to make the honeypot field less obvious to spammers reading the DOM by mimicking the structure of other fields.

`type='hidden'` wasn't doing anything to stem the flow of spammers on our site.

Appreciate that there are other mechanisms that can be used to prevent spam signups (CAPTCHA, math question) but a honeypot is the least intrusive, and plugins like Gravity Forms show that this can work fine.

What I've done here has lowered the rate of spam on our site, but the only way to make it better is to take the inline styles and put them in an external stylesheet - it appears that at least one bot can see the `display:none;` for the wrapper div and leave the input alone. 

The cleanest place for this to live would be inside the RCP stylesheet. Appreciate that this is not ideal, but it's a single rule to add. 